### PR TITLE
Ensure systemd-timesyncd is available on Debian 11

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -15,6 +15,12 @@
     state: absent
     purge: true
 
+- name: Ensure systemd-timesyncd is available on Debian 11
+  apt:
+    name: systemd-timesyncd
+    install_recommends: false
+  when: ansible_distribution_major_version == '11'
+
 - name: Enable systemd-timesyncd service
   systemd:
     name: systemd-timesyncd


### PR DESCRIPTION
https://github.com/aminvakil/ansible-role-os-initialize/runs/5746519605?check_suite_focus=true#step:5:113